### PR TITLE
Remove NextGen version handling code from mysql package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/sqlc-dev/marino
 go 1.25
 
 require (
-	github.com/coreos/go-semver v0.3.1
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/pingcap/errors"
 	"github.com/sqlc-dev/marino/format"
 )
@@ -33,76 +32,16 @@ const (
 	// one with MySQL compatibility version, with this fixed then we can parse TiDB
 	// version from ServerVersion.
 	VersionSeparator = "-TiDB-"
-
-	// tidbXReleaseVersionPrefix is used in `select tidb_version()` output of nextgen.
-	tidbXReleaseVersionPrefix = "CLOUD."
-
-	legacyTiDBReleaseVersionPlaceholder = "v8.4.0-this-is-a-placeholder"
-	// tidbXPlaceholderReleaseVersion is the default release version for nextgen when no
-	// release version is injected during build, such as when running in IDE.
-	tidbXPlaceholderReleaseVersion = "v26.3.0-this-is-a-placeholder"
-	// TiDBXVerMinYear is set to 2025 just for sanity check.
-	// our first release of next-gen since 2025
-	TiDBXVerMinYear = 2025
-	// TiDBXVerMaxYear is set to 2099 just for sanity check, we don't expect the
-	// year part of release version to be larger than this.
-	// enough for now.
-	TiDBXVerMaxYear = 2099
 )
 
 // Version information.
 var (
 	// TiDBReleaseVersion is initialized by (git describe --tags) in Makefile.
-	TiDBReleaseVersion = legacyTiDBReleaseVersionPlaceholder
+	TiDBReleaseVersion = "v8.4.0-this-is-a-placeholder"
 
 	// ServerVersion is the version information of this tidb-server in MySQL's format.
 	ServerVersion = fmt.Sprintf("%s%s%s", mysqlCompatibilityVersion, VersionSeparator, TiDBReleaseVersion)
 )
-
-// NormalizeTiDBReleaseVersionForNextGen rewrites the legacy placeholder into a nextgen
-// placeholder that follows `v[2-digit-year].[month].[fix-version]`.
-// pkg/parser is Golang project, it cannot use kerneltype pkg to conditionally
-// compile different code for next-gen and classic, so we have to rewrite the
-// placeholder value in this function.
-func NormalizeTiDBReleaseVersionForNextGen(releaseVersion string) string {
-	// the version is not set if we run next-gen tidb from IDE.
-	if releaseVersion == legacyTiDBReleaseVersionPlaceholder {
-		return tidbXPlaceholderReleaseVersion
-	}
-	return releaseVersion
-}
-
-// BuildTiDBXReleaseVersion converts mysql.TiDBReleaseVersion into the nextgen visible
-// version format `CLOUD.<4-digit-year-2-digit-month>.<fix-version><optional-pre-release>`.
-func BuildTiDBXReleaseVersion(releaseVersion string) (string, error) {
-	if !strings.HasPrefix(releaseVersion, "v") {
-		return "", errors.Errorf("invalid TiDB release version %q, should start with 'v'", releaseVersion)
-	}
-	rawVer := strings.TrimPrefix(releaseVersion, "v")
-	ver, err := semver.NewVersion(rawVer)
-	if err != nil {
-		return "", errors.Errorf("invalid TiDB release version %q, expect a semantic version", releaseVersion)
-	}
-	year := 2000 + ver.Major
-	if year < TiDBXVerMinYear || year > TiDBXVerMaxYear || ver.Minor < 1 || ver.Minor > 12 {
-		return "", errors.Errorf("invalid TiDB release version %q, the semantic version part should be in [2-digit-year].[month].[fix-version]-[xxx] format", releaseVersion)
-	}
-	preRelease := string(ver.PreRelease)
-	if preRelease != "" {
-		preRelease = "-" + preRelease
-	}
-	return fmt.Sprintf("%s%d%02d.%d%s", tidbXReleaseVersionPrefix, year, ver.Minor, ver.Patch, preRelease), nil
-}
-
-// BuildTiDBXServerVersion converts mysql.TiDBReleaseVersion into MySQL server version
-// format `8.0.11-TiDB-CLOUD.<4-digit-year-2-digit-month>.<fix-version>`.
-func BuildTiDBXServerVersion(releaseVersion string) (string, error) {
-	tidbXReleaseVersion, err := BuildTiDBXReleaseVersion(releaseVersion)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s%s%s", mysqlCompatibilityVersion, VersionSeparator, tidbXReleaseVersion), nil
-}
 
 // Header information.
 const (

--- a/mysql/const_test.go
+++ b/mysql/const_test.go
@@ -14,10 +14,8 @@
 package mysql
 
 import (
-	"testing"
-
 	"reflect"
-	"strings"
+	"testing"
 )
 
 func TestSQLMode(t *testing.T) {
@@ -102,55 +100,5 @@ func TestVersionSeparator(t *testing.T) {
 	// DO NOT change the value of VersionSeparator.
 	if !reflect.DeepEqual("-TiDB-", VersionSeparator) {
 		t.Fatalf("got %v, want %v", VersionSeparator, "-TiDB-")
-	}
-}
-
-func TestBuildTiDBXReleaseVersion(t *testing.T) {
-	tidbXVersion, err := BuildTiDBXReleaseVersion("v26.3.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual("CLOUD.202603.0", tidbXVersion) {
-		t.Fatalf("got %v, want %v", tidbXVersion, "CLOUD.202603.0")
-	}
-
-	tidbXVersion, err = BuildTiDBXReleaseVersion("v26.3.0-xxx")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual("CLOUD.202603.0-xxx", tidbXVersion) {
-		t.Fatalf("got %v, want %v", tidbXVersion, "CLOUD.202603.0-xxx")
-	}
-
-	serverVersion, err := BuildTiDBXServerVersion("v26.3.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual("8.0.11-TiDB-CLOUD.202603.0", serverVersion) {
-		t.Fatalf("got %v, want %v", serverVersion, "8.0.11-TiDB-CLOUD.202603.0")
-	}
-
-	serverVersion, err = BuildTiDBXServerVersion("v26.3.0-xxx")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual("8.0.11-TiDB-CLOUD.202603.0-xxx", serverVersion) {
-		t.Fatalf("got %v, want %v", serverVersion, "8.0.11-TiDB-CLOUD.202603.0-xxx")
-	}
-
-	for _, ver := range []string{"26.1.1", "v26xxxx", "v24.1.1", "v26.0.1", "v26.13.1"} {
-		_, err = BuildTiDBXReleaseVersion(ver)
-		if err == nil || !strings.Contains(err.Error(), "invalid TiDB release version") {
-			t.Fatalf("expected error containing %q, got %v", "invalid TiDB release version", err)
-		}
-	}
-}
-
-func TestNormalizeTiDBReleaseVersionForNextGen(t *testing.T) {
-	if !reflect.DeepEqual(tidbXPlaceholderReleaseVersion, NormalizeTiDBReleaseVersionForNextGen(legacyTiDBReleaseVersionPlaceholder)) {
-		t.Fatalf("got %v, want %v", NormalizeTiDBReleaseVersionForNextGen(legacyTiDBReleaseVersionPlaceholder), tidbXPlaceholderReleaseVersion)
-	}
-	if !reflect.DeepEqual("v26.3.0", NormalizeTiDBReleaseVersionForNextGen("v26.3.0")) {
-		t.Fatalf("got %v, want %v", NormalizeTiDBReleaseVersionForNextGen("v26.3.0"), "v26.3.0")
 	}
 }


### PR DESCRIPTION
## Summary
This PR removes NextGen-specific version handling functionality from the mysql package, including version conversion utilities and related constants. The code being removed was used to convert TiDB release versions into NextGen-specific formats.

## Key Changes
- Removed `NormalizeTiDBReleaseVersionForNextGen()` function that converted legacy placeholders to NextGen placeholders
- Removed `BuildTiDBXReleaseVersion()` function that converted semantic versions to NextGen format (`CLOUD.<year-month>.<fix>`)
- Removed `BuildTiDBXServerVersion()` function that built MySQL-compatible server version strings with NextGen format
- Removed NextGen-related constants:
  - `tidbXReleaseVersionPrefix` ("CLOUD.")
  - `tidbXPlaceholderReleaseVersion` (v26.3.0 placeholder)
  - `TiDBXVerMinYear` and `TiDBXVerMaxYear` (year validation bounds)
- Inlined `legacyTiDBReleaseVersionPlaceholder` constant value directly into `TiDBReleaseVersion` initialization
- Removed corresponding unit tests for the deleted functions
- Removed `github.com/coreos/go-semver` dependency from go.mod

## Implementation Details
The `TiDBReleaseVersion` variable now uses the literal placeholder value `"v8.4.0-this-is-a-placeholder"` instead of referencing a named constant, simplifying the initialization while maintaining the same behavior for the legacy version format.

https://claude.ai/code/session_011eUiTSJanyruVRnV5b7fJw