### PR TITLE
Upgrade to Go 1.26 and apply go fix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Regenerate parser
         run: |
@@ -30,6 +30,9 @@ jobs:
 
       - name: Build
         run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
 
       - name: Test
         run: go test ./...

--- a/ast/base_test.go
+++ b/ast/base_test.go
@@ -294,7 +294,7 @@ func buildNoQuotesClause() string {
 func buildMixedQuery(n int) string {
 	var b strings.Builder
 	b.WriteString("SELECT * FROM t1 WHERE ")
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i > 0 {
 			b.WriteString(" OR ")
 		}
@@ -310,7 +310,7 @@ func buildMixedQuery(n int) string {
 func buildQuery(clause string, n int) string {
 	var b strings.Builder
 	b.WriteString("SELECT * FROM t1 WHERE ")
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i > 0 {
 			b.WriteString(" OR ")
 		}

--- a/ast/misc.go
+++ b/ast/misc.go
@@ -3993,7 +3993,7 @@ type HintTimeRange struct {
 //	will be parsed into a LeadingList like:
 //	Items = [HintTable("a"), LeadingList{[HintTable("b"), HintTable("c")]}, HintTable("d")]
 type LeadingList struct {
-	Items []interface{}
+	Items []any
 }
 
 // HintSetVar is the payload of `SET_VAR` hint

--- a/generate_keyword/genkeyword.go
+++ b/generate_keyword/genkeyword.go
@@ -110,7 +110,7 @@ func main() {
 	}
 
 	section := sectionNone
-	for _, line := range strings.Split(string(parserData), "\n") {
+	for line := range strings.SplitSeq(string(parserData), "\n") {
 		if line == "" { // Empty line indicates section end
 			section = sectionNone
 		} else if strings.Contains(line, reservedKeywordStart) {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sqlc-dev/marino
 
-go 1.25
+go 1.26
 
 require golang.org/x/text v0.19.0

--- a/goyacc/go.mod
+++ b/goyacc/go.mod
@@ -1,6 +1,6 @@
 module github.com/sqlc-dev/marino/goyacc
 
-go 1.25
+go 1.26
 
 require (
 	github.com/sqlc-dev/marino v0.0.0

--- a/parser/consistent_test.go
+++ b/parser/consistent_test.go
@@ -81,11 +81,11 @@ func extractMiddle(str, startMarker, endMarker string) string {
 		return ""
 	}
 	str = str[startIdx+len(startMarker):]
-	endIdx := strings.Index(str, endMarker)
-	if endIdx == -1 {
+	before, _, ok := strings.Cut(str, endMarker)
+	if !ok {
 		return ""
 	}
-	return str[:endIdx]
+	return before
 }
 
 func extractQuotedWords(strs []string) []string {

--- a/parser/digester_test.go
+++ b/parser/digester_test.go
@@ -296,6 +296,6 @@ func BenchmarkDigestSprintf(b *testing.B) {
 	digest1 := genRandDigest("abc")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fmt.Sprintf("%x", digest1)
+		_ = fmt.Sprintf("%x", digest1)
 	}
 }

--- a/parser/hintparser_test.go
+++ b/parser/hintparser_test.go
@@ -374,13 +374,13 @@ func TestParseHint(t *testing.T) {
 				{
 					HintName: ast.NewCIStr("LEADING"),
 					HintData: &ast.LeadingList{
-						Items: []interface{}{
+						Items: []any{
 							&ast.HintTable{TableName: ast.NewCIStr("a")},
 							&ast.LeadingList{
-								Items: []interface{}{
+								Items: []any{
 									&ast.HintTable{TableName: ast.NewCIStr("b")},
 									&ast.LeadingList{
-										Items: []interface{}{
+										Items: []any{
 											&ast.HintTable{TableName: ast.NewCIStr("c")},
 											&ast.HintTable{TableName: ast.NewCIStr("d")},
 										},
@@ -404,7 +404,7 @@ func TestParseHint(t *testing.T) {
 				{
 					HintName: ast.NewCIStr("LEADING"),
 					HintData: &ast.LeadingList{
-						Items: []interface{}{
+						Items: []any{
 							&ast.HintTable{TableName: ast.NewCIStr("a")},
 							&ast.HintTable{TableName: ast.NewCIStr("b")},
 							&ast.HintTable{TableName: ast.NewCIStr("c")},
@@ -424,15 +424,15 @@ func TestParseHint(t *testing.T) {
 				{
 					HintName: ast.NewCIStr("LEADING"),
 					HintData: &ast.LeadingList{
-						Items: []interface{}{
+						Items: []any{
 							&ast.LeadingList{
-								Items: []interface{}{
+								Items: []any{
 									&ast.HintTable{TableName: ast.NewCIStr("a")},
 									&ast.HintTable{TableName: ast.NewCIStr("b")},
 								},
 							},
 							&ast.LeadingList{
-								Items: []interface{}{
+								Items: []any{
 									&ast.HintTable{TableName: ast.NewCIStr("c")},
 									&ast.HintTable{TableName: ast.NewCIStr("d")},
 								},
@@ -454,10 +454,10 @@ func TestParseHint(t *testing.T) {
 				{
 					HintName: ast.NewCIStr("LEADING"),
 					HintData: &ast.LeadingList{
-						Items: []interface{}{
+						Items: []any{
 							&ast.HintTable{TableName: ast.NewCIStr("x")},
 							&ast.LeadingList{
-								Items: []interface{}{
+								Items: []any{
 									&ast.HintTable{TableName: ast.NewCIStr("y")},
 									&ast.HintTable{TableName: ast.NewCIStr("z")},
 								},

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -6456,7 +6456,7 @@ Int64Num:
 	{
 		v, rangeErrMsg := getInt64FromNUM($1)
 		if len(rangeErrMsg) != 0 {
-			yylex.AppendError(yylex.Errorf(rangeErrMsg))
+			yylex.AppendError(yylex.Errorf("%s", rangeErrMsg))
 			return 1
 		}
 		$$ = v


### PR DESCRIPTION
Bump go directive in both modules to 1.26 and apply the modernization
fixes that go fix produces under the new toolchain (range-over-int,
strings.SplitSeq, strings.Cut, interface{} -> any).