### PR TITLE
Remove stale TiDB references from documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security Vulnerability Disclosure and Response Process
 
-The primary goal of this process is to reduce the total exposure time of users to publicly known vulnerabilities. TiDB security team is responsible for the entire vulnerability management process, including internal communication and external disclosure.
-
-If you find a vulnerability or encounter a security incident involving vulnerabilities of this repository, please report it as soon as possible to the TiDB security team (security@tidb.io).
+If you find a vulnerability or encounter a security incident involving this
+repository, please report it privately via GitHub's "Report a vulnerability"
+feature on the repository's Security tab.
 
 Please kindly help provide as much vulnerability information as possible in the following format:
 
@@ -22,7 +22,8 @@ The asterisk (*) indicates the required field.
 
 # Response Time
 
-The TiDB security team will confirm the vulnerabilities and contact you within 2 working days after your submission.
+We will confirm the vulnerabilities and contact you within a reasonable time
+after your submission.
 
 We will publicly thank you after fixing the security vulnerability. To avoid negative impact, please keep the vulnerability confidential until we fix it. We would appreciate it if you could obey the following code of conduct:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,25 +19,11 @@ touch main.go
 
 ## Import Dependencies
 
-First, you need to use `go get` to fetch the dependencies through git hash. The git hashes are available in [release page](https://github.com/pingcap/tidb/releases). Take `v7.5.0` as an example:
+First, you need to use `go get` to fetch the dependency:
 
 ```bash
-go get -v github.com/sqlc-dev/marino@069631e
+go get -v github.com/sqlc-dev/marino
 ```
-
-> **NOTE**
-> 
-> The parser was merged into TiDB repo since v5.3.0. So you can only choose version v5.3.0 or higher in this TiDB repo.
->
-> You may want to use advanced API on expressions (a kind of AST node), such as numbers, string literals, booleans, nulls, etc. It is strongly recommended using the `types` package in TiDB repo with the following command:
->
-> ```bash
-> go get -v github.com/pingcap/tidb/pkg/types/parser_driver@069631e
-> ```
-> and import it in your golang source code:
-> ```go
-> import _ "github.com/pingcap/tidb/pkg/types/parser_driver"
-> ```
 
 Your directory should contain the following three files:
 ```
@@ -104,7 +90,7 @@ If the parser runs properly, you should get a result like this:
 > Here are a few things you might want to know:
 > - To use a parser, a `parser_driver` is required. It decides how to parse the basic data types in SQL.
 >
->   You can use [`github.com/sqlc-dev/marino/test_driver`](https://pkg.go.dev/github.com/sqlc-dev/marino/test_driver) as the `parser_driver` for test. Again, if you need advanced features, please use the `parser_driver` in TiDB (run `go get -v github.com/pingcap/tidb/types/parser_driver@069631e` and import it).
+>   You can use [`github.com/sqlc-dev/marino/test_driver`](https://pkg.go.dev/github.com/sqlc-dev/marino/test_driver) as the `parser_driver`.
 > - The instantiated parser object is not goroutine safe and not lightweight. It is better to keep it in a single goroutine, and reuse it if possible.
 > - Warning: the `parser.result` object is being reused without being properly reset or copied. This can cause unexpected behavior or errors if the object is used for multiple parsing operations or concurrently in multiple goroutines. To avoid these issues, make a copy of `parser.result` object before calling `parser.Parse()` again or before using it in another goroutine, or create a new `parser` object altogether for each new parsing operation.
 


### PR DESCRIPTION
SECURITY.md previously pointed to the TiDB security team and
security@tidb.io, neither of which are valid for this fork.
Replace with a generic policy directing users to GitHub's
security advisory feature.

docs/quickstart.md included broken instructions to fetch
dependencies via TiDB git hashes and to install TiDB's
parser_driver for advanced features. Drop those sections
and recommend the in-tree test_driver instead.